### PR TITLE
Use official links to Swagger specs

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -59,12 +59,12 @@ module.exports = {
   'swagger': {
     'src' : [
       {
-        'url': 'https://raw.githubusercontent.com/APIs-guru/api-models/master/clickmeter.com/v2/',
+        'url': 'https://apis-guru.github.io/api-models/clickmeter.com/v2/',
         'filename': 'swagger.json',
         'moduleName': 'ClickMeter'
       },
       {
-        'url': 'https://raw.githubusercontent.com/APIs-guru/api-models/master/googleapis.com/gmail/v1/',
+        'url': 'https://apis-guru.github.io/api-models/googleapis.com/gmail/v1/',
         'filename': 'swagger.json',
         'moduleName': 'Gmail'
       },


### PR DESCRIPTION
My collection became too big to keep all APIs folder in root of repo.
So I plan to move them into subdir, I search Github to find who's using RAW links.
This PR switch it to official links which I try to keep stable as much as possible.

P.S. Thank you for using my project :smiley: 
